### PR TITLE
Add ESC keyboard shortcut for closing the overlay

### DIFF
--- a/demo/klangdemo/core.cljs
+++ b/demo/klangdemo/core.cljs
@@ -2,7 +2,7 @@
   (:require
    [klang.core :as k :refer-macros [info! warn! erro!]]))
 
-(k/show!)
+(k/toggle-showing! true)
 (info! :may-wanna-click "on on this message" js/document.head)
 
 (defn foo [x]

--- a/src/cljs/klang/core.cljs
+++ b/src/cljs/klang/core.cljs
@@ -339,7 +339,7 @@
                          :type "text"
                          :defaultValue (:search @db "")
                          :placeholder "Search"})
-          (h "span"))
+          (h "span" #js{}))
         (h "button" #js{:style #js{:cursor "pointer"
                                    :color (if (:frozen-at @db) "orange" "green")}
                         :onClick #(toggle-freeze)}

--- a/src/cljs/klang/core.cljs
+++ b/src/cljs/klang/core.cljs
@@ -332,7 +332,10 @@
         (h "input" #js{:style #js{:background "#000"
                                   :color "white"
                                   :width "350px"}
+                       :id "search"
+                       :tabIndex 1
                        :onChange (fn [e] (!! assoc :search (.. e -target -value)))
+                       :autoFocus true
                        :type "text"
                        :defaultValue (:search @db "")
                        :placeholder "Search"})
@@ -409,7 +412,7 @@
 
 
 (defn install-toggle-shortcut!
-  "Installs a Keyboard Shortcut handler that show/hide the log overlay.
+  "Installs a Keyboard Shortcut handler that toggles the visibility of the log overlay.
    Call the return function to unregister."
   [shortcut]
   ;; If previous one exist just unregister it:
@@ -421,7 +424,7 @@
       handler
       KeyboardShortcutHandler.EventType.SHORTCUT_TRIGGERED
       (fn [e] (toggle-showing!)))
-    (js/console.info "Klang: Keyboard shortcut installed:" shortcut)
+    (js/console.info "Klang: Toggle overlay keyboard shortcut installed:" shortcut)
     (!! assoc :shortcut-toggle-keys #(.unregisterShortcut handler shortcut))))
 
 (defn install-hide-shortcut!
@@ -437,9 +440,8 @@
       handler
       KeyboardShortcutHandler.EventType.SHORTCUT_TRIGGERED
       (fn [e] (toggle-showing! false)))
-    (js/console.info "Klang: Keyboard hide shortcut installed:" shortcut)
-    (!! assoc :shortcut-keys #(.unregisterShortcut handler shortcut))))
-    
+    (js/console.info "Klang: Hide overlay keyboard shortcut installed:" shortcut)
+    (!! assoc :shortcut-hide-keys #(.unregisterShortcut handler shortcut))))
 
 (defn set-max-logs!
   "Only keep the last n logs. If nil: No truncating."

--- a/src/cljs/klang/core.cljs
+++ b/src/cljs/klang/core.cljs
@@ -312,7 +312,6 @@
              (.push aout (render-log-event lg-ev)))))
        aout)))
 
-
 (defn- render-overlay
   "Renders the entire log message overlay in a div when :showing? is true."
   []
@@ -329,16 +328,18 @@
                              :width "calc(100% - 12px)"
                              :justifyContent "center"
                              :display "flex"}}
-        (h "input" #js{:style #js{:background "#000"
-                                  :color "white"
-                                  :width "350px"}
-                       :id "search"
-                       :tabIndex 1
-                       :onChange (fn [e] (!! assoc :search (.. e -target -value)))
-                       :autoFocus true
-                       :type "text"
-                       :defaultValue (:search @db "")
-                       :placeholder "Search"})
+        (if (:showing? @db)
+          (h "input" #js{:style #js{:background "#000"
+                                    :color "white"
+                                    :width "350px"}
+                         :id "klang-search"
+                         :tabIndex 1
+                         :onChange (fn [e] (!! assoc :search (.. e -target -value)))
+                         :autoFocus true
+                         :type "text"
+                         :defaultValue (:search @db "")
+                         :placeholder "Search"})
+          (h "span"))
         (h "button" #js{:style #js{:cursor "pointer"
                                    :color (if (:frozen-at @db) "orange" "green")}
                         :onClick #(toggle-freeze)}


### PR DESCRIPTION
Re: #6 

Also sets the search field to autofocus, but this only works on document load and not when the overlay visibility is toggled.

NB: There is probably room for refactoring the install of the keyboard shortcuts. Right now the code is duplicated, but I couldn't figure out a clean way to DRY it up.