### PR TITLE
Add klang.dev function to start figwheel from the REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,29 @@ One simple hack is to:
 This will avoid the warning. However, even with the warnings your program should
 run just fine (and compile fine by Google Closure compiler).
 
+## Contribute
+
+Depending on your workflow you can choose to start just figwheel or to first start
+a REPL and start figwheel from there.
+
+### Just figwheel
+```bash
+$ lein figheel
+```
+
+### REPL then figwheel
+You will want to do it this way if you want to jack in with Emacs CIDER or connect
+to the REPL from other tools/editors.
+
+```bash
+$ lein repl
+```
+
+Then at the REPL prompt:
+```
+klang.dev=> (start)
+```
+
 ## License
 
 Copyright &copy; 2015-2017 Andre Rauh. Distributed under the

--- a/env/dev/clj/klang/dev.clj
+++ b/env/dev/clj/klang/dev.clj
@@ -1,18 +1,9 @@
 (ns klang.dev
-  (:require [cemerick.piggieback :as piggieback]
-            [weasel.repl.websocket :as weasel]
-            [leiningen.core.main :as lein]))
+  (:use [figwheel-sidecar.repl-api :as ra]))
 
-;; Usually started from the nREPL
-(defn browser-repl []
-  (piggieback/cljs-repl
-   :repl-env
-   (weasel/repl-env
-    :ip "localhost"
-    :port 9001)))
+(defn start []
+  (ra/start-figwheel!)
+  (ra/cljs-repl "dev"))
 
-;; Usually already started in a separate JVM with "lein figwheel"
-(defn start-figwheel []
-  (future
-    (print "Starting figwheel.\n")
-    (lein/-main ["figwheel"])))
+(defn stop []
+  (ra/stop-figwheel!))

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,17 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :source-paths ["src/cljs"]
+  :source-paths ["src/cljs" "env/dev/clj"]
+
+  :profiles {:dev
+              {:source-paths ["env/dev/clj"]
+               :dependencies [[figwheel-sidecar "0.5.4-6" :exclusions [org.clojure/clojure]]
+                              [com.cemerick/piggieback "0.2.2" :exclusions [org.clojure/clojure]]
+                              [org.clojure/tools.nrepl "0.2.10"]]
+               :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
+                              :init-ns klang.dev
+                              :welcome (println "\nWelcome! I'm happy you want to contribute to Klang!\nCall (start) to fire up figwheel.")}}}
+
 
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/clojurescript "1.9.229" :classifier "aot" :scope "provided"]
@@ -32,7 +42,7 @@
 
   :cljsbuild
   {:builds
-   {:app {:source-paths ["src/cljs" "demo"]
+   {:dev {:source-paths ["src/cljs" "demo"]
           :figwheel true
           :compiler {:output-to     "resources/public/js/app.js"
                      :output-dir    "resources/public/js/out"
@@ -65,7 +75,7 @@
                       :optimizations :advanced
                       :pretty-print  false}}}}
 
-   :jar-exclusions     [#"resources" #"demo" #"docs" #"env" #"public" #"test" #"main" #"\.swp" #"templates"]
+  :jar-exclusions     [#"resources" #"demo" #"docs" #"env" #"public" #"test" #"main" #"\.swp" #"templates"]
    :uberjar {:hooks [leiningen.cljsbuild]
              ;;:hooks [leiningen.cljsbuild]
              ;;:env {:production true}


### PR DESCRIPTION
Starting figwheel from the REPL enables jacking in from Emacs CIDER and other tools. 