### PR TITLE
Select default search text when overlay shows up

### DIFF
--- a/src/cljs/klang/core.cljs
+++ b/src/cljs/klang/core.cljs
@@ -20,7 +20,8 @@
     [goog.object :as gobj]
     [goog.string :as gstring]
     [goog.string.format]
-    [goog.style :as gstyle])
+    [goog.style :as gstyle]
+    [goog.dom :as dom])
   (:import
     goog.ui.KeyboardShortcutHandler))
 
@@ -62,7 +63,7 @@
 (defn possibly-set-lifecycle!
   "This is all done for performance... Smaller and more used functions can easier get optimized."
   [spec name f]
-  (when-not (empty? f)
+  (when-not (nil? f)
     (gobj/set spec name f))
   nil)
 
@@ -312,6 +313,25 @@
              (.push aout (render-log-event lg-ev)))))
        aout)))
 
+(def render-search-box
+  (component #js{:name "KlangSearch"
+                 :key-fn (fn [props] (:id props))
+                 :did-mount (fn [state]
+                              (let [el (dom/getElement "klang-search")]
+                                (.select el))
+                              state)}
+             (fn [default-value]
+               (h "input" #js{:style #js{:background "#000"
+                                         :color "white"
+                                         :width "350px"}
+                              :id "klang-search"
+                              :tabIndex 1
+                              :onChange (fn [e] (!! assoc :search (.. e -target -value)))
+                              :autoFocus true
+                              :type "text"
+                              :defaultValue default-value
+                              :placeholder "Search"}))))
+
 (defn- render-overlay
   "Renders the entire log message overlay in a div when :showing? is true."
   []
@@ -329,16 +349,7 @@
                              :justifyContent "center"
                              :display "flex"}}
         (if (:showing? @db)
-          (h "input" #js{:style #js{:background "#000"
-                                    :color "white"
-                                    :width "350px"}
-                         :id "klang-search"
-                         :tabIndex 1
-                         :onChange (fn [e] (!! assoc :search (.. e -target -value)))
-                         :autoFocus true
-                         :type "text"
-                         :defaultValue (:search @db "")
-                         :placeholder "Search"})
+          (render-search-box (:search @db ""))
           (h "span" #js{}))
         (h "button" #js{:style #js{:cursor "pointer"
                                    :color (if (:frozen-at @db) "orange" "green")}

--- a/src/cljs/klang/core.cljs
+++ b/src/cljs/klang/core.cljs
@@ -19,9 +19,7 @@
     [goog.events :as gevents]
     [goog.object :as gobj]
     [goog.string :as gstring]
-    [goog.string.format]
-    [goog.style :as gstyle]
-    [goog.dom :as dom])
+    [goog.style :as gstyle])
   (:import
     goog.ui.KeyboardShortcutHandler))
 
@@ -314,23 +312,24 @@
        aout)))
 
 (def render-search-box
-  (component #js{:name "KlangSearch"
-                 :key-fn (fn [props] (:id props))
-                 :did-mount (fn [state]
-                              (let [el (dom/getElement "klang-search")]
-                                (.select el))
-                              state)}
-             (fn [default-value]
-               (h "input" #js{:style #js{:background "#000"
-                                         :color "white"
-                                         :width "350px"}
-                              :id "klang-search"
-                              :tabIndex 1
-                              :onChange (fn [e] (!! assoc :search (.. e -target -value)))
-                              :autoFocus true
-                              :type "text"
-                              :defaultValue default-value
-                              :placeholder "Search"}))))
+  (let [search-box-id "klang-search"]
+    (component #js{:name "KlangSearch"
+                   :key-fn (fn [props] (:id props))
+                   :did-mount (fn [state]
+                                (let [el (js/document.getElementById search-box-id)]
+                                  (.select el))
+                                state)}
+               (fn [default-value]
+                 (h "input" #js{:style #js{:background "#000"
+                                           :color "white"
+                                           :width "350px"}
+                                :id search-box-id
+                                :tabIndex 1
+                                :onChange (fn [e] (!! assoc :search (.. e -target -value)))
+                                :autoFocus true
+                                :type "text"
+                                :defaultValue default-value
+                                :placeholder "Search"})))))
 
 (defn- render-overlay
   "Renders the entire log message overlay in a div when :showing? is true."

--- a/src/cljs/klang/core.cljs
+++ b/src/cljs/klang/core.cljs
@@ -19,6 +19,7 @@
     [goog.events :as gevents]
     [goog.object :as gobj]
     [goog.string :as gstring]
+    [goog.string.format]
     [goog.style :as gstyle])
   (:import
     goog.ui.KeyboardShortcutHandler))


### PR DESCRIPTION
Now supports an awesome workflow! 😀 Opening the overlay keeps the old search as previous (of course) but selects it so that if you are interested in something different this time, you just type the new search term.

I have not bumped the version since I'm unsure about how versioning works in general and about this repository's version strategy in particular. 